### PR TITLE
feat: Implement CloudFormation force deletion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,194 @@
-# blast-busted-cloudformation
-Welcome. This tool is for blasting away CFN stacks that you cannot do anything with. Poor, poor stack.
+# CloudFormation Stack Deleter (cfn-stack-deleter)
+
+## Overview/Description
+
+The CloudFormation Stack Deleter is a Python script designed to assist in the deletion of AWS CloudFormation stacks, particularly those that encounter issues due to lingering resources that CloudFormation itself cannot or will not delete. This tool attempts to pre-emptively identify and remove/clean up these problematic resources before initiating the standard CloudFormation stack deletion process.
+
+Key capabilities include:
+*   Handling non-empty S3 buckets.
+*   Clearing images from ECR repositories.
+*   Terminating associated EC2 instances (including disabling termination protection).
+*   Detaching and deleting associated EBS volumes.
+*   Cleaning up IAM roles by detaching policies and removing them from instance profiles.
+*   Detaching IAM policies from stack-specific roles to aid in their removal.
+*   Persistent state saving and loading, allowing resumption of operations.
+*   A `--dry-run` mode to preview actions without making changes.
+*   Detailed logging to both console and a file.
+
+## !! WARNING: DESTRUCTIVE OPERATIONS !!
+
+**This tool performs DESTRUCTIVE operations on your AWS resources, including deleting S3 objects, ECR images, EC2 instances, EBS volumes, IAM roles, and IAM policies. It is designed to forcefully remove resources to facilitate CloudFormation stack deletion.**
+
+*   **USE WITH EXTREME CAUTION.**
+*   **ALWAYS test with the `--dry-run` flag first in any new environment or with any new stack.**
+*   **It is highly recommended to test this script on non-production environments until you are thoroughly familiar with its behavior and impact.**
+*   **You are solely responsible for any actions taken by this script and any resulting data loss or resource deletion.**
+*   **Backup any critical data or resources before using this tool.**
+*   **Review the resources and proposed actions carefully during the confirmation prompt.**
+
+## Prerequisites
+
+*   **Python**: Python 3.7 or higher.
+*   **AWS Account**: An AWS account with permissions to manage CloudFormation and the resources within the stacks you intend to delete (S3, ECR, EC2, IAM, STS).
+*   **AWS CLI (Recommended)**: Configured AWS CLI, especially if you plan to use named profiles or require SSO login capabilities that Boto3 can leverage.
+*   **Boto3**: The AWS SDK for Python. This is the primary dependency.
+
+## Installation
+
+1.  **Clone the Repository**:
+    ```bash
+    git clone <repository_url> # Replace <repository_url> with the actual URL
+    cd cfn-stack-deleter
+    ```
+
+2.  **Install Dependencies**:
+    The script primarily relies on Boto3. If you don't have it installed, or want to ensure you have a recent version:
+    ```bash
+    pip install boto3
+    ```
+    (It's good practice to use a virtual environment.)
+
+## Configuration
+
+### AWS Authentication
+
+The script uses the standard Boto3 credential resolution chain. You can configure credentials via:
+
+1.  **AWS CLI Named Profiles**:
+    Use the `--profile <your-profile-name>` argument. Ensure the profile is configured in your `~/.aws/config` or `~/.aws/credentials` files.
+    ```bash
+    python cfn_stack_deleter.py --stack-name my-stack --region us-east-1 --profile my-dev-profile
+    ```
+
+2.  **IAM Role Assumption**:
+    Use the `--role-arn <role-arn-to-assume>` argument. The credentials used to run the script (from default chain or a specified `--profile`) must have `sts:AssumeRole` permission for the target role.
+    ```bash
+    python cfn_stack_deleter.py --stack-name my-stack --region us-east-1 --role-arn arn:aws:iam::123456789012:role/MyDeletionRole
+    ```
+    You can also specify `--role-session-name <session-name>` (defaults to "CfnStackDeleterSession").
+
+3.  **Environment Variables**:
+    Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`.
+
+4.  **EC2 Instance Profile**:
+    If running on an EC2 instance, the script will automatically use the instance's IAM role if no other credentials are provided.
+
+### IAM Permissions
+
+The IAM user or role executing this script requires extensive permissions to describe and delete various resources across multiple services. Minimally, it would need permissions like:
+
+*   `cloudformation:DescribeStacks`, `cloudformation:ListStackResources`, `cloudformation:DeleteStack`
+*   `s3:ListBucketVersions`, `s3:DeleteObject`, `s3:DeleteObjectVersion` (for all objects in target buckets)
+*   `ecr:ListImages`, `ecr:BatchDeleteImage`
+*   `ec2:DescribeInstances`, `ec2:ModifyInstanceAttribute` (for termination protection), `ec2:TerminateInstances`
+*   `ec2:DescribeVolumes`, `ec2:DetachVolume`, `ec2:DeleteVolume`
+*   `iam:GetRole`, `iam:ListAttachedRolePolicies`, `iam:DetachRolePolicy`, `iam:ListRolePolicies`, `iam:DeleteRolePolicy`, `iam:ListInstanceProfilesForRole`, `iam:RemoveRoleFromInstanceProfile`, `iam:DeleteRole`
+*   `iam:GetPolicy`, `iam:ListEntitiesForPolicy`, `iam:DetachRolePolicy` (for customer-managed policies)
+*   `sts:GetCallerIdentity` (used by the script to display current identity)
+*   `sts:AssumeRole` (if using the `--role-arn` feature)
+
+**It is strongly recommended to grant these permissions based on the principle of least privilege and only to trusted entities.** Consider creating a specific IAM role for running this script with only the necessary permissions for the cleanup tasks.
+
+## Usage
+
+```
+python cfn_stack_deleter.py --help
+```
+
+Below is a representation of the help output:
+
+```
+usage: cfn_stack_deleter.py [-h] --stack-name STACK_NAME --region REGION [--dry-run] [--profile PROFILE] [--role-arn ROLE_ARN] [--role-session-name ROLE_SESSION_NAME]
+
+Deletes an AWS CloudFormation stack and attempts to pre-delete associated resources
+that might cause deletion failures (e.g., non-empty S3 buckets, ECR repositories with images,
+EC2 instances, EBS volumes, and IAM roles/policies by detaching them from stack resources).
+
+options:
+  -h, --help            show this help message and exit
+  --stack-name STACK_NAME
+                        The name or ARN of the CloudFormation stack to delete.
+  --region REGION       The AWS region where the stack exists (e.g., 'us-east-1').
+  --dry-run             Perform a dry run: show what would be done without making any changes. State files might still be saved if a scan is performed.
+
+authentication options:
+  --profile PROFILE     The AWS CLI profile to use for authentication. If not specified, default SDK credential chain is used.
+  --role-arn ROLE_ARN   The ARN of the IAM role to assume for AWS operations (e.g., 'arn:aws:iam::123456789012:role/MyRole'). If provided, the script will attempt to assume this role.
+  --role-session-name ROLE_SESSION_NAME
+                        An identifier for the assumed role session. Default: 'CfnStackDeleterSession'.
+
+Examples:
+  python cfn_stack_deleter.py --stack-name my-test-stack --region us-east-1
+  python cfn_stack_deleter.py --stack-name my-app-stack --region eu-west-1 --profile my-aws-profile --dry-run
+  python cfn_stack_deleter.py --stack-name shared-service --region us-west-2 --role-arn arn:aws:iam::123456789012:role/MyCrossAccountRole
+
+Logs are stored in files named like 'cfn_deleter_<stack_name>_<timestamp>.log' in the current directory.
+```
+
+### Common Examples:
+
+1.  **Perform a dry run on a stack:**
+    ```bash
+    python cfn_stack_deleter.py --stack-name my-problem-stack --region us-east-1 --dry-run
+    ```
+
+2.  **Delete a stack using default credentials:**
+    ```bash
+    python cfn_stack_deleter.py --stack-name my-problem-stack --region us-east-1
+    ```
+    (After reviewing the dry run and confirming the actions!)
+
+3.  **Delete a stack using a specific AWS profile:**
+    ```bash
+    python cfn_stack_deleter.py --stack-name my-problem-stack --region us-west-2 --profile my-admin-profile
+    ```
+
+4.  **Delete a stack by assuming an IAM role:**
+    ```bash
+    python cfn_stack_deleter.py --stack-name my-problem-stack --region eu-central-1 --role-arn arn:aws:iam::098765432109:role/StackDeletionRole
+    ```
+
+## Features
+
+*   **Handles Problematic Resources**:
+    *   `AWS::S3::Bucket`: Empties buckets (all versions and delete markers).
+    *   `AWS::ECR::Repository`: Deletes all images.
+    *   `AWS::EC2::Instance`: Disables termination protection and terminates instances.
+    *   `AWS::EC2::Volume`: Detaches and deletes EBS volumes.
+    *   `AWS::IAM::Role`: Detaches managed policies, deletes inline policies, and removes from instance profiles before deleting the role.
+    *   `AWS::IAM::Policy`: Detaches customer-managed policies from roles within the same stack to facilitate role deletion. (Does not delete the policy itself.)
+*   **State Persistence**: Saves the scanned resource state to a local JSON file (`cfn_deleter_state_<stack_name>.json`). On re-runs, it can load this state and ask the user to resume or re-scan, potentially saving time on large stacks.
+*   **Dry Run Mode (`--dry-run`)**: Allows users to see what actions the script *would* take without making any actual changes to AWS resources.
+*   **Comprehensive Logging**:
+    *   Console output for INFO level messages (and above).
+    *   Detailed DEBUG level logging to a file (`cfn_deleter_<stack_name>_<timestamp>.log`).
+    *   Log messages clearly indicate when in dry run mode.
+*   **User Confirmation**: Displays a summary of resources and planned actions, then requires explicit user confirmation ("yes") before proceeding with any destructive operations.
+*   **Flexible Authentication**: Supports AWS named profiles and IAM role assumption.
+
+## How it Works (Simplified)
+
+1.  **Initialization**: Sets up logging and parses command-line arguments. Establishes an AWS session using specified credentials/region.
+2.  **State Handling**: Checks for an existing state file (`cfn_deleter_state_<stack_name>.json`). If found, prompts the user to resume or re-scan.
+3.  **Resource Discovery**: If not resuming or no state file, it calls `DescribeStacks` (to get Stack ID and verify existence) and `ListStackResources` to get a list of all resources in the stack. This list is then saved to the state file (unless in dry run for the save itself).
+4.  **Pre-Deletion Summary & Confirmation**: Displays all discovered resources and highlights those that will be targeted by specific pre-processing handlers. Prompts the user for explicit confirmation before proceeding.
+5.  **Resource Pre-Processing**: Iterates through the list of stack resources. If a resource matches a known problematic type (S3, ECR, EC2, IAM), it calls a dedicated handler function for that resource type. These handlers attempt to clean up the resource (e.g., empty a bucket, delete images, terminate an instance). This step respects the `--dry-run` flag.
+6.  **CloudFormation Stack Deletion**: After attempting to clean up individual resources, the script calls the standard Boto3 `delete_stack` API for the CloudFormation stack. This step is skipped if in `--dry-run` mode.
+7.  **Wait for Completion**: The script waits for the stack deletion to complete using a Boto3 waiter.
+
+## Testing
+
+Unit tests are provided in the `tests/` directory and can be run using:
+
+```bash
+python -m unittest discover -s tests
+```
+The tests use `unittest.mock` to simulate AWS API calls and verify the script's logic without interacting with actual AWS resources.
+
+## Contributing
+
+Contributions are welcome! Please feel free to fork the repository, make your changes, and submit a pull request. For major changes, please open an issue first to discuss.
+
+## License
+
+This project is licensed under the MIT License. (Assuming MIT, if a `LICENSE` file exists with different content, this should be updated).

--- a/cfn_stack_deleter.py
+++ b/cfn_stack_deleter.py
@@ -1,0 +1,628 @@
+# This script will be used to delete AWS CloudFormation stacks.
+# It will include logic for AWS authentication, resource fetching, and deletion.
+
+import boto3
+import botocore # For ClientError
+import argparse
+import json
+import os
+import shutil
+from datetime import datetime
+import time
+import logging # Import logging module
+
+# Global logger instance
+logger = logging.getLogger("CfnStackDeleter") # Keep this global for the script's own logging
+
+# Argument parsing function for testability
+def parse_arguments(argv):
+    parser = argparse.ArgumentParser(
+        description="""Deletes an AWS CloudFormation stack and attempts to pre-delete associated resources
+that might cause deletion failures (e.g., non-empty S3 buckets, ECR repositories with images,
+EC2 instances, EBS volumes, and IAM roles/policies by detaching them from stack resources).""",
+        epilog="""Examples:
+  python cfn_stack_deleter.py --stack-name my-test-stack --region us-east-1
+  python cfn_stack_deleter.py --stack-name my-app-stack --region eu-west-1 --profile my-aws-profile --dry-run
+  python cfn_stack_deleter.py --stack-name shared-service --region us-west-2 --role-arn arn:aws:iam::123456789012:role/MyCrossAccountRole
+
+Logs are stored in files named like 'cfn_deleter_<stack_name>_<timestamp>.log' in the current directory.
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter # Allows for better formatting of epilog
+    )
+    parser.add_argument("--stack-name", required=True,
+                        help="The name or ARN of the CloudFormation stack to delete.")
+    parser.add_argument("--region", required=True,
+                        help="The AWS region where the stack exists (e.g., 'us-east-1').")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Perform a dry run: show what would be done without making any changes. "
+                             "State files might still be saved if a scan is performed.")
+
+    auth_group = parser.add_argument_group('authentication options')
+    auth_group.add_argument("--profile",
+                            help="The AWS CLI profile to use for authentication. "
+                                 "If not specified, default SDK credential chain is used.")
+    auth_group.add_argument("--role-arn",
+                            help="The ARN of the IAM role to assume for AWS operations (e.g., 'arn:aws:iam::123456789012:role/MyRole'). "
+                                 "If provided, the script will attempt to assume this role.")
+    auth_group.add_argument("--role-session-name", default="CfnStackDeleterSession",
+                            help="An identifier for the assumed role session. Default: '%(default)s'.")
+
+    return parser.parse_args(argv)
+
+
+def setup_logging(stack_name_for_log, is_dry_run=False): # Added is_dry_run
+    """Configures logging for console and file."""
+    # Use the global logger instance
+    logger.setLevel(logging.DEBUG)
+
+    # Clear existing handlers (if any, e.g., during re-runs in a session)
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+
+    # Console Handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    formatter_str = '%(asctime)s - %(levelname)s - %(message)s'
+    if is_dry_run: # Prepend [DRY RUN] to console messages if dry_run is true
+        formatter_str = '[DRY RUN] ' + formatter_str
+    formatter = logging.Formatter(formatter_str)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    # File Handler
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    dry_run_suffix = "_DRYRUN" if is_dry_run else ""
+    log_file_name = f"cfn_deleter_{stack_name_for_log}_{timestamp}{dry_run_suffix}.log"
+    try:
+        fh = logging.FileHandler(log_file_name)
+        fh.setLevel(logging.DEBUG)
+        file_formatter_str = '%(asctime)s - %(levelname)s - [%(module)s.%(funcName)s:%(lineno)d] - %(message)s'
+        if is_dry_run: # Prepend [DRY RUN] to file messages if dry_run is true
+             file_formatter_str = '[DRY RUN] ' + file_formatter_str
+        file_formatter = logging.Formatter(file_formatter_str)
+        fh.setFormatter(file_formatter)
+        logger.addHandler(fh)
+        logger.info(f"Detailed logging to file: {log_file_name}") # This will also be prepended in dry run
+    except Exception as e:
+        logger.error(f"Failed to set up file handler for {log_file_name}: {e}")
+
+
+def main():
+    # Import sys for main execution context if not already there
+    import sys
+    args = parse_arguments(sys.argv[1:])
+
+    # Setup logging early, using stack_name for the log file
+    # Logger is already global, setup_logging will use it.
+    setup_logging(args.stack_name, args.dry_run)
+
+    logger.info(f"Script starting for CloudFormation stack: '{args.stack_name}' in region '{args.region}'. Dry run: {args.dry_run}")
+
+    if args.profile and args.role_arn:
+        logger.debug("Using --profile to source credentials for --role-arn assumption is an advanced flow.")
+        pass
+
+    session_params = {"region_name": args.region}
+    account_id = None
+
+    try:
+        logger.debug(f"Attempting to establish AWS session. Profile: {args.profile}, Role ARN: {args.role_arn}, Region: {args.region}")
+        if args.role_arn:
+            logger.info(f"Attempting to assume role: {args.role_arn} with session name: {args.role_session_name}")
+            sts_client_params = {"region_name": args.region}
+            if args.profile:
+                 logger.debug(f"Using profile '{args.profile}' to create STS client for assuming role '{args.role_arn}'.")
+                 initial_session = boto3.Session(profile_name=args.profile, region_name=args.region)
+                 sts_client = initial_session.client('sts')
+            else:
+                 logger.debug("Using default credential chain for STS client to assume role.")
+                 sts_client = boto3.client('sts', region_name=args.region)
+
+            assumed_role_object = sts_client.assume_role(RoleArn=args.role_arn, RoleSessionName=args.role_session_name)
+            credentials = assumed_role_object['Credentials']
+            session_params.update({
+                'aws_access_key_id': credentials['AccessKeyId'],
+                'aws_secret_access_key': credentials['SecretAccessKey'],
+                'aws_session_token': credentials['SessionToken'],
+            })
+            logger.info(f"Successfully assumed role '{args.role_arn}'.")
+        elif args.profile:
+            session_params["profile_name"] = args.profile
+            logger.info(f"Using AWS CLI profile: '{args.profile}' for the session.")
+        else:
+            logger.info("Using default AWS SDK credential chain for the session.")
+
+        session = boto3.Session(**session_params)
+
+        cfn_client = session.client("cloudformation")
+        s3_client = session.client("s3")
+        ecr_client = session.client("ecr")
+        ec2_client = session.client("ec2")
+        iam_client = session.client("iam")
+
+        identity_client = session.client('sts')
+        caller_identity = identity_client.get_caller_identity()
+        account_id = caller_identity['Account']
+        logger.info(f"Running as: {caller_identity['Arn']} in Account: {account_id}")
+        logger.debug("Boto3 session and all AWS service clients initialized successfully.")
+
+    except botocore.exceptions.NoCredentialsError:
+        logger.error("No AWS credentials found by Boto3. Please configure your credentials (env vars, shared file, SSO, or instance profile).")
+        return
+    except botocore.exceptions.ProfileNotFound as e:
+        profile_name_err = args.profile or "(AWS_PROFILE env var)"
+        logger.error(f"Error: AWS profile '{profile_name_err}' not found. Exception: {e}")
+        return
+    except botocore.exceptions.NoRegionError as e:
+        logger.error(f"Boto3 region error: {e}. Configure region via --region, env var (AWS_REGION/AWS_DEFAULT_REGION), or AWS config file.")
+        return
+    except botocore.exceptions.ClientError as e:
+        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
+        error_message = e.response.get('Error', {}).get('Message', str(e))
+        logger.error(f"AWS API ClientError during session setup or identity check: {error_code} - {error_message}")
+        if error_code == "AccessDenied" and args.role_arn: logger.error("Specific check: Access denied for sts:AssumeRole. Ensure base credentials have permission or role trust policy is correct.")
+        elif error_code == "ExpiredToken": logger.error("Specific check: AWS security token is expired. Please refresh your credentials.")
+        return
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during AWS session setup: {e}", exc_info=True)
+        return
+
+    try:
+        delete_stack(cfn_client, s3_client, ecr_client, ec2_client, iam_client,
+                     args.stack_name, args.region, account_id, args.dry_run) # Pass dry_run
+        logger.info(f"Script execution for stack '{args.stack_name}' completed.")
+    except Exception as e:
+        logger.error(f"An unhandled exception occurred during delete_stack operation: {e}", exc_info=True)
+        logger.info(f"Script execution for stack '{args.stack_name}' failed.")
+
+
+def get_stack_resources(cfn_client, stack_name):
+    logger.info(f"Listing resources and details for stack '{stack_name}'...")
+    stack_id = None
+    try:
+        stack_description_response = cfn_client.describe_stacks(StackName=stack_name)
+        if not stack_description_response.get('Stacks'):
+            logger.warning(f"Stack '{stack_name}' not found by describe_stacks.")
+            return None, None
+        stack_info = stack_description_response['Stacks'][0]
+        stack_id = stack_info['StackId']
+        logger.info(f"Successfully described stack. Stack ID: {stack_id}, Status: {stack_info.get('StackStatus')}")
+    except botocore.exceptions.ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code")
+        if "does not exist" in str(e).lower() or "stacknotfound" in str(e).lower() or error_code == "ValidationError":
+            logger.warning(f"Stack '{stack_name}' does not exist or is an invalid name (describe_stacks). Error: {e}")
+        elif error_code == "AccessDenied":
+            logger.error(f"Access denied for describe_stacks on '{stack_name}'. Error: {e}")
+        else:
+            logger.error(f"AWS ClientError describing stack '{stack_name}': {e}", exc_info=True)
+        return None, None
+
+    detailed_resources = []
+    next_token = None
+    try:
+        logger.debug(f"Listing all resources for stack '{stack_name}' (ID: {stack_id})...")
+        while True:
+            response = cfn_client.list_stack_resources(StackName=stack_id, NextToken=next_token) if next_token else cfn_client.list_stack_resources(StackName=stack_id)
+            for summary in response.get('StackResourceSummaries', []):
+                detailed_resources.append({
+                    'LogicalResourceId': summary.get('LogicalResourceId'),
+                    'PhysicalResourceId': summary.get('PhysicalResourceId'),
+                    'ResourceType': summary.get('ResourceType'),
+                    'ResourceStatus': summary.get('ResourceStatus'),
+                    'DriftInformationSummary': summary.get('DriftInformationSummary', {'StackResourceDriftStatus': 'NOT_CHECKED'})
+                })
+            next_token = response.get('NextToken')
+            if not next_token: break
+        logger.info(f"Found {len(detailed_resources)} resources for stack '{stack_name}'.")
+        return detailed_resources, stack_id
+    except botocore.exceptions.ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code")
+        if error_code == "AccessDenied":
+            logger.error(f"Access denied listing resources for stack '{stack_name}'. Error: {e}")
+        else:
+            logger.error(f"AWS ClientError listing resources for stack '{stack_name}': {e}", exc_info=True)
+        return None, stack_id
+    except Exception as e:
+        logger.error(f"Unexpected error listing stack resources for '{stack_name}': {e}", exc_info=True)
+        return None, stack_id
+
+STATE_FILE_PREFIX = "cfn_deleter_state_"
+def get_state_filename(stack_name): return f"{STATE_FILE_PREFIX}{stack_name}.json"
+
+def save_state(stack_name, stack_id, resources, dry_run=False): # Added dry_run
+    if dry_run:
+        logger.info(f"[DRY RUN] Would save state for stack '{stack_name}' if not in dry run mode.")
+        return
+    filename = get_state_filename(stack_name)
+    state = { "stack_name": stack_name, "stack_id": stack_id, "last_saved_utc": datetime.utcnow().isoformat(), "resources": resources }
+    try:
+        with open(filename, 'w') as f: json.dump(state, f, indent=2)
+        logger.info(f"State saved for stack '{stack_name}' to {filename}")
+    except IOError as e: logger.error(f"Error saving state to {filename}: {e}", exc_info=True)
+
+def load_state(stack_name):
+    filename = get_state_filename(stack_name)
+    if not os.path.exists(filename):
+        logger.debug(f"State file {filename} not found.")
+        return None
+    try:
+        with open(filename, 'r') as f: state = json.load(f)
+        logger.info(f"State loaded for stack '{stack_name}' from {filename}")
+        return state
+    except (IOError, json.JSONDecodeError) as e:
+        logger.error(f"Error loading state from {filename}: {e}. It might be corrupted.", exc_info=True)
+        return None
+
+def backup_state_file(stack_name, dry_run=False): # Added dry_run
+    if dry_run: # No actual file operations in dry run
+        logger.info(f"[DRY RUN] Would backup state file for {stack_name} if one exists and not in dry run mode.")
+        return
+    filename = get_state_filename(stack_name)
+    if os.path.exists(filename):
+        backup_filename = f"{filename}.{datetime.now().strftime('%Y%m%d%H%M%S')}.bak"
+        try:
+            shutil.move(filename, backup_filename)
+            logger.info(f"Backed up existing state file to {backup_filename}")
+        except shutil.Error as e: logger.error(f"Error backing up state file {filename}: {e}", exc_info=True)
+
+def delete_stack(cfn_client, s3_client, ecr_client, ec2_client, iam_client,
+                 stack_name, region, account_id, dry_run=False): # Added dry_run
+    logger.info(f"Initiating deletion for stack '{stack_name}' in {region} (Account: {account_id}). DRY RUN: {dry_run}")
+    stack_resources = None
+    stack_id = None
+    loaded_state = load_state(stack_name) # load_state doesn't need dry_run, it's read-only
+    if loaded_state:
+        logger.info(f"Found state for '{loaded_state['stack_name']}' (ID: {loaded_state.get('stack_id', 'N/A')}, {len(loaded_state['resources'])} resources, saved {loaded_state.get('last_saved_utc', 'N/A')}).")
+        while True:
+            raw_choice = input("Resume with saved state (R), or Re-scan all resources (S)? ")
+            choice = raw_choice.strip().upper()
+            if choice in ['R', 'S']:
+                logger.info(f"User chose: {choice}")
+                break
+            print("Invalid choice. Please enter 'R' or 'S'.") # Keep print for direct user feedback
+        if choice == 'R':
+            logger.info("Resuming with loaded state.")
+            stack_resources = loaded_state['resources']
+            stack_id = loaded_state.get('stack_id')
+        else:
+            logger.info("Re-scanning. Backing up old state...")
+            backup_state_file(stack_name, dry_run) # Pass dry_run
+
+    if stack_resources is None:
+        logger.info("-" * 50 + "\nStep 1: Retrieving stack resource details from AWS...")
+        fetched_resources, fetched_stack_id = get_stack_resources(cfn_client, stack_name)
+        if fetched_resources is None:
+            logger.error("Halting: Failed to retrieve resources.")
+            return
+        stack_resources = fetched_resources
+        stack_id = fetched_stack_id
+        if stack_id: save_state(stack_name, stack_id, stack_resources, dry_run) # Pass dry_run
+
+    if not stack_resources:
+        logger.info(f"No resources found for stack '{stack_name}' (ID: {stack_id or 'N/A'}). Might be empty or already deleted.")
+    else:
+        logger.info(f"\nDiscovered resources for stack '{stack_name}' (ID: {stack_id or 'N/A'}):")
+        # Display resource summary
+        print("\n" + "="*20 + " STACK RESOURCE SUMMARY " + "="*20) # Use print for direct visibility
+        for res in stack_resources:
+            drift_status = res.get('DriftInformationSummary', {}).get('StackResourceDriftStatus', 'N/A')
+            print(f"  - LogicalID: {res['LogicalResourceId']}")
+            print(f"    PhysicalID: {res.get('PhysicalResourceId', 'N/A')}")
+            print(f"    Type: {res['ResourceType']}")
+            print(f"    Status: {res['ResourceStatus']}")
+            print(f"    Drift: {drift_status}")
+            print("    " + "-"*30)
+        print("="*62 + "\n")
+
+
+    logger.info("\nStep 2: Identifying resources for pre-processing...")
+    clients = { "s3": s3_client, "ecr": ecr_client, "ec2": ec2_client, "iam": iam_client, "cfn": cfn_client }
+    resource_handlers = {
+        "AWS::S3::Bucket": handle_s3_bucket, "AWS::ECR::Repository": handle_ecr_repository,
+        "AWS::EC2::Instance": handle_ec2_instance, "AWS::EC2::Volume": handle_ec2_volume,
+        "AWS::IAM::Role": handle_iam_role, "AWS::IAM::Policy": handle_iam_policy,
+    }
+
+    resources_to_preprocess = []
+    if stack_resources:
+        for resource in stack_resources:
+            if resource['ResourceType'] in resource_handlers:
+                resources_to_preprocess.append(resource)
+
+    if resources_to_preprocess:
+        logger.info("The following resources will be targeted by pre-processing handlers:")
+        for res in resources_to_preprocess:
+            logger.info(f"  - {res['LogicalResourceId']} (Type: {res['ResourceType']}, PhysicalID: {res.get('PhysicalResourceId', 'N/A')})")
+    else:
+        logger.info("No resources identified for specific pre-processing handlers.")
+
+    # Confirmation Prompt
+    print("\n" + "="*20 + " CONFIRMATION REQUIRED " + "="*20) # Print for visibility
+    if dry_run:
+        print("This is a DRY RUN. No actual changes will be made to your resources or the stack.")
+        prompt_message = "Proceed to show proposed actions? (yes/no): "
+    else:
+        print("WARNING: The script will attempt to modify/delete the resources listed above and then delete the stack.")
+        prompt_message = f"Are you sure you want to proceed with these actions on stack '{stack_name}'? This is irreversible. (yes/no): "
+
+    confirm_input = input(prompt_message).strip().lower()
+    logger.info(f"User confirmation input: '{confirm_input}'")
+    if confirm_input != "yes":
+        logger.info("User did not confirm. Exiting script without performing destructive actions.")
+        return
+
+    logger.info("User confirmed. Proceeding with actions.")
+    logger.info("\nStep 2a: Executing pre-processing for identified resources...")
+    processed_count = 0
+    if stack_resources: # Re-check as it might be empty
+        for resource in stack_resources: # Iterate all, handlers will pick based on type
+            handler = resource_handlers.get(resource['ResourceType'])
+            if handler:
+                pid = resource.get('PhysicalResourceId')
+                lid = resource.get('LogicalResourceId')
+                rtype = resource.get('ResourceType')
+                logger.debug(f"Calling handler for resource type: {rtype} - {lid}")
+                if not pid:
+                    logger.warning(f"Skipping {lid} (Type: {rtype}): no PhysicalResourceId.")
+                    continue
+                logger.info(f"Pre-processing {lid} (Type: {rtype}, ID: {pid})")
+                try:
+                    handler(clients, resource, stack_resources, stack_name, region, account_id, dry_run) # Pass dry_run
+                    processed_count += 1
+                except Exception as e:
+                    logger.error(f"Error pre-processing {pid} (Type: {rtype}): {e}. Continuing...", exc_info=True)
+        logger.info(f"Finished pre-processing. {processed_count} resources had specific handlers called.")
+    else: logger.info("No resources in stack to pre-process.")
+
+
+    logger.info(f"\nStep 3: Deleting CloudFormation stack '{stack_name}' (ID: {stack_id or 'N/A'}).")
+    if dry_run:
+        logger.info(f"[DRY RUN] Would attempt to delete CloudFormation stack '{stack_name}' (ID: {stack_id or 'N/A'}).")
+        logger.info("[DRY RUN] Skipping actual stack deletion and waiter.")
+        return # End of dry run operations for delete_stack
+
+    try:
+        target_id = stack_id if stack_id else stack_name
+        try:
+            logger.debug(f"Describing stack '{target_id}' before attempting deletion.")
+            s_info = cfn_client.describe_stacks(StackName=target_id)['Stacks'][0]
+            if s_info['StackStatus'] == 'DELETE_COMPLETE':
+                logger.info(f"Stack '{target_id}' already DELETE_COMPLETE.")
+                return
+            logger.info(f"Stack '{target_id}' status before delete: {s_info['StackStatus']}")
+        except botocore.exceptions.ClientError as e:
+            if "does not exist" in str(e).lower() or "stacknotfound" in str(e).lower():
+                logger.info(f"Stack '{target_id}' already deleted (cannot describe).")
+                return
+            else: logger.warning(f"Pre-delete describe_stacks failed for '{target_id}': {e}. Proceeding with delete attempt.")
+
+        logger.info(f"Issuing delete_stack command for '{target_id}'.")
+        cfn_client.delete_stack(StackName=target_id)
+        logger.info(f"Delete request for '{target_id}' submitted. Waiting for completion (up to 1 hour)...")
+        waiter = cfn_client.get_waiter('stack_delete_complete')
+        waiter.wait(StackName=target_id, WaiterConfig={'Delay': 30, 'MaxAttempts': 120})
+        logger.info(f"Stack '{target_id}' deleted successfully.")
+    except botocore.exceptions.WaiterError as e:
+        logger.error(f"Waiter error for stack '{target_id}' deletion: {e}", exc_info=True)
+    except botocore.exceptions.ClientError as e:
+        err_code = e.response.get("Error", {}).get("Code")
+        if "does not exist" in str(e).lower() or "stacknotfound" in str(e).lower() or ("ValidationError" in err_code and "does not exist" in e.response.get('Error',{}).get('Message','').lower()):
+            logger.warning(f"Stack '{stack_name}' (ID: {stack_id or 'N/A'}) not found or already deleted. Error: {e}")
+        else: logger.error(f"ClientError deleting stack '{stack_name}' (ID: {stack_id or 'N/A'}): {e}", exc_info=True)
+    except Exception as e: logger.error(f"Unexpected error deleting stack '{stack_name}' (ID: {stack_id or 'N/A'}): {e}", exc_info=True)
+
+# --- Resource Handler Signatures Updated to include dry_run ---
+def handle_s3_bucket(clients, res_details, stack_res_list, stack_name, region, acc_id, dry_run=False):
+    b_name = res_details.get('PhysicalResourceId')
+    lid = res_details.get('LogicalResourceId')
+    if not b_name: logger.warning(f"S3 Bucket {lid} no PhysicalResourceId. Skip."); return
+    logger.debug(f"Calling empty_s3_bucket for {lid} ({b_name}) with dry_run={dry_run}")
+    empty_s3_bucket(clients['s3'], b_name, lid, dry_run)
+
+def handle_ecr_repository(clients, res_details, stack_res_list, stack_name, region, acc_id, dry_run=False):
+    repo_name = res_details.get('PhysicalResourceId')
+    lid = res_details.get('LogicalResourceId')
+    if not repo_name: logger.warning(f"ECR Repo {lid} no PhysicalResourceId. Skip."); return
+    logger.debug(f"Calling delete_ecr_repository_images for {lid} ({repo_name}) with dry_run={dry_run}")
+    delete_ecr_repository_images(clients['ecr'], repo_name, lid, dry_run)
+
+def handle_ec2_instance(clients, res_details, stack_res_list, stack_name, region, acc_id, dry_run=False):
+    inst_id = res_details.get('PhysicalResourceId')
+    log_id = res_details.get('LogicalResourceId')
+    ec2 = clients['ec2']
+    if not inst_id: logger.warning(f"EC2 Instance {log_id} no PhysicalResourceId. Skip."); return
+    logger.info(f"Handling EC2 Instance: {log_id} (ID: {inst_id})")
+    try:
+        desc_response = ec2.describe_instances(InstanceIds=[inst_id])
+        if not desc_response.get('Reservations'):
+             logger.info(f"Instance {inst_id} for {log_id} not found by describe_instances. Likely already terminated.")
+             return
+        inst_info = desc_response['Reservations'][0]['Instances'][0]
+
+        if inst_info['State']['Name'] in ['terminated', 'shutting-down']:
+            logger.info(f"Instance {inst_id} ({log_id}) already {inst_info['State']['Name']}. Skip."); return
+
+        if dry_run:
+            logger.info(f"[DRY RUN] Would check and disable termination protection if enabled for {inst_id} ({log_id}).")
+            logger.info(f"[DRY RUN] Would terminate instance {inst_id} ({log_id}).")
+            return
+
+        term_protection = ec2.describe_instance_attribute(InstanceId=inst_id, Attribute='disableApiTermination')['DisableApiTermination']['Value']
+        if term_protection:
+            logger.info(f"Disabling termination protection for {inst_id} ({log_id})...")
+            ec2.modify_instance_attribute(InstanceId=inst_id, DisableApiTermination={'Value': False})
+
+        logger.info(f"Terminating instance {inst_id} ({log_id})...")
+        ec2.terminate_instances(InstanceIds=[inst_id])
+        logger.info(f"Termination for {inst_id} ({log_id}) submitted.")
+    except botocore.exceptions.ClientError as e:
+        if "InvalidInstanceID.NotFound" in str(e): logger.warning(f"EC2 Instance {inst_id} ({log_id}) not found.")
+        else: logger.error(f"AWS ClientError EC2 instance {inst_id} ({log_id}): {e}", exc_info=True); raise
+    except Exception as e: logger.error(f"Error EC2 instance {inst_id} ({log_id}): {e}", exc_info=True); raise
+
+def handle_ec2_volume(clients, res_details, stack_res_list, stack_name, region, acc_id, dry_run=False):
+    vol_id = res_details.get('PhysicalResourceId')
+    log_id = res_details.get('LogicalResourceId')
+    ec2 = clients['ec2']
+    if not vol_id: logger.warning(f"EC2 Volume {log_id} no PhysicalResourceId. Skip."); return
+    logger.info(f"Handling EC2 Volume: {log_id} (ID: {vol_id})")
+    try:
+        vol_desc = ec2.describe_volumes(VolumeIds=[vol_id])
+        if not vol_desc.get('Volumes'):
+            logger.info(f"Volume {vol_id} ({log_id}) not found. Skipping.")
+            return
+        vol_info = vol_desc['Volumes'][0]
+
+        if vol_info['State'] in ['deleted', 'deleting']:
+            logger.info(f"Volume {vol_id} ({log_id}) already {vol_info['State']}. Skip."); return
+
+        if dry_run:
+            if vol_info.get('Attachments'): logger.info(f"[DRY RUN] Would detach volume {vol_id} ({log_id}) from {vol_info['Attachments'][0]['InstanceId']}.")
+            logger.info(f"[DRY RUN] Would delete volume {vol_id} ({log_id}).")
+            return
+
+        if vol_info.get('Attachments'):
+            logger.info(f"Detaching volume {vol_id} ({log_id}) from {vol_info['Attachments'][0]['InstanceId']}...")
+            ec2.detach_volume(VolumeId=vol_id)
+            waiter = ec2.get_waiter('volume_available')
+            logger.info(f"Waiting for volume {vol_id} ({log_id}) to become available...")
+            waiter.wait(VolumeIds=[vol_id], WaiterConfig={'Delay': 10, 'MaxAttempts': 30})
+            logger.info(f"Volume {vol_id} ({log_id}) is now available.")
+
+        logger.info(f"Deleting volume {vol_id} ({log_id})...")
+        ec2.delete_volume(VolumeId=vol_id)
+        logger.info(f"Deletion for {vol_id} ({log_id}) submitted.")
+    except botocore.exceptions.ClientError as e:
+        if "InvalidVolume.NotFound" in str(e): logger.warning(f"EC2 Volume {vol_id} ({log_id}) not found.")
+        else: logger.error(f"AWS ClientError EC2 volume {vol_id} ({log_id}): {e}", exc_info=True); raise
+    except Exception as e: logger.error(f"Error EC2 volume {vol_id} ({log_id}): {e}", exc_info=True); raise
+
+def handle_iam_role(clients, res_details, stack_res_list, stack_name, region, acc_id, dry_run=False):
+    pid = res_details.get('PhysicalResourceId')
+    log_id = res_details.get('LogicalResourceId')
+    iam = clients['iam']
+    if not pid: logger.warning(f"IAM Role {log_id} no PhysicalResourceId. Skip."); return
+    r_name = pid if ':' not in pid else pid.split('/')[-1]
+    logger.info(f"Handling IAM Role: {log_id} (Name: {r_name})")
+    try:
+        iam.get_role(RoleName=r_name)
+
+        if dry_run:
+            logger.info(f"[DRY RUN] Would list and detach managed policies from {r_name} ({log_id}).")
+            logger.info(f"[DRY RUN] Would list and delete inline policies from {r_name} ({log_id}).")
+            logger.info(f"[DRY RUN] Would list and remove role {r_name} ({log_id}) from instance profiles.")
+            logger.info(f"[DRY RUN] Would delete IAM role {r_name} ({log_id}).")
+            return
+
+        for page in iam.get_paginator('list_attached_role_policies').paginate(RoleName=r_name):
+            for pol in page.get('AttachedPolicies', []):
+                logger.info(f"Detaching managed policy {pol['PolicyArn']} from {r_name} ({log_id})...")
+                iam.detach_role_policy(RoleName=r_name, PolicyArn=pol['PolicyArn'])
+        for page in iam.get_paginator('list_role_policies').paginate(RoleName=r_name):
+            for pol_name in page.get('PolicyNames', []):
+                logger.info(f"Deleting inline policy {pol_name} from {r_name} ({log_id})...")
+                iam.delete_role_policy(RoleName=r_name, PolicyName=pol_name)
+        for page in iam.get_paginator('list_instance_profiles_for_role').paginate(RoleName=r_name):
+            for prof in page.get('InstanceProfiles', []):
+                prof_name = prof['InstanceProfileName']
+                logger.info(f"Removing role {r_name} ({log_id}) from instance profile {prof_name}...")
+                iam.remove_role_from_instance_profile(InstanceProfileName=prof_name, RoleName=r_name)
+
+        logger.info(f"Deleting IAM role {r_name} ({log_id})...")
+        iam.delete_role(RoleName=r_name)
+        logger.info(f"IAM role {r_name} ({log_id}) deleted.")
+    except iam.exceptions.NoSuchEntityException: logger.warning(f"IAM Role {r_name} ({log_id}) not found.")
+    except iam.exceptions.DeleteConflictException as e: logger.error(f"IAM Role {r_name} ({log_id}) delete conflict: {e}. Might be in use.", exc_info=True); raise
+    except Exception as e: logger.error(f"Error IAM role {r_name} ({log_id}): {e}", exc_info=True); raise
+
+def handle_iam_policy(clients, res_details, stack_res_list, stack_name, region, acc_id, dry_run=False):
+    pol_arn = res_details.get('PhysicalResourceId')
+    log_id = res_details.get('LogicalResourceId')
+    iam = clients['iam']
+    if not pol_arn: logger.warning(f"IAM Policy {log_id} no PhysicalResourceId. Skip."); return
+    logger.info(f"Handling IAM Policy: {log_id} (ARN: {pol_arn})")
+    if pol_arn.startswith("arn:aws:iam::aws:policy/"):
+        logger.info(f"Policy {pol_arn} ({log_id}) is AWS managed. Skip."); return
+    try:
+        iam.get_policy(PolicyArn=pol_arn)
+        stack_role_names = { (r.get('PhysicalResourceId') if ':' not in r.get('PhysicalResourceId','') else r.get('PhysicalResourceId','').split('/')[-1])
+                             for r in stack_res_list if r['ResourceType'] == 'AWS::IAM::Role' and r.get('PhysicalResourceId') }
+        logger.debug(f"Policy {pol_arn} ({log_id}). Will detach from stack roles if found: {stack_role_names or 'None in stack'}")
+
+        if dry_run:
+            logger.info(f"[DRY RUN] Would list entities for policy {pol_arn} ({log_id}) and detach from stack-specific roles: {stack_role_names or 'None identified'}.")
+            logger.info(f"[DRY RUN] Policy {pol_arn} ({log_id}) itself would not be deleted by this script directly.")
+            return
+
+        detached_count = 0
+        for page in iam.get_paginator('list_entities_for_policy').paginate(PolicyArn=pol_arn):
+            for role in page.get('PolicyRoles', []):
+                if role['RoleName'] in stack_role_names:
+                    logger.info(f"Detaching {pol_arn} ({log_id}) from stack role {role['RoleName']}...")
+                    try:
+                        iam.detach_role_policy(RoleName=role['RoleName'], PolicyArn=pol_arn)
+                        detached_count += 1
+                    except Exception as de: logger.error(f"Error detaching {pol_arn} ({log_id}) from {role['RoleName']}: {de}", exc_info=True)
+        if detached_count > 0: logger.info(f"Detached {pol_arn} ({log_id}) from {detached_count} stack roles.")
+        else: logger.debug(f"Policy {pol_arn} ({log_id}) not found attached to any identified stack roles.")
+        logger.info(f"Not deleting policy {pol_arn} ({log_id}) itself. CFN should handle if unattached & stack-specific.")
+    except iam.exceptions.NoSuchEntityException: logger.warning(f"IAM Policy {pol_arn} ({log_id}) not found.")
+    except Exception as e: logger.error(f"Error IAM policy {pol_arn} ({log_id}): {e}", exc_info=True); raise
+
+def empty_s3_bucket(s3_client, bucket_name, logical_id="N/A", dry_run=False): # Added dry_run
+    logger.info(f"Processing S3 bucket: {bucket_name} (Resource: {logical_id})")
+    if dry_run:
+        logger.info(f"[DRY RUN] Would empty S3 bucket: {bucket_name} (Resource: {logical_id}).")
+        return
+    try:
+        paginator = s3_client.get_paginator('list_object_versions')
+        objects_to_delete = {'Objects': []}
+        object_count = 0
+        logger.debug(f"Listing objects and versions in {bucket_name}...")
+        for page in paginator.paginate(Bucket=bucket_name):
+            for version_type in ['Versions', 'DeleteMarkers']:
+                if version_type in page:
+                    for obj in page[version_type]:
+                        objects_to_delete['Objects'].append({'Key': obj['Key'], 'VersionId': obj['VersionId']})
+                        object_count +=1
+            if len(objects_to_delete['Objects']) >= 1000:
+                logger.debug(f"Deleting batch of {len(objects_to_delete['Objects'])} objects/versions from {bucket_name}...")
+                s3_client.delete_objects(Bucket=bucket_name, Delete=objects_to_delete)
+                objects_to_delete = {'Objects': []}
+        if len(objects_to_delete['Objects']) > 0:
+            logger.debug(f"Deleting final batch of {len(objects_to_delete['Objects'])} objects/versions from {bucket_name}...")
+            s3_client.delete_objects(Bucket=bucket_name, Delete=objects_to_delete)
+        if object_count > 0: logger.info(f"Successfully emptied S3 bucket: {bucket_name} ({object_count} objects/versions deleted).")
+        else: logger.info(f"S3 bucket: {bucket_name} was already empty or had no versions to delete.")
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchBucket': logger.warning(f"S3 bucket '{bucket_name}' not found (Resource: {logical_id}).")
+        else: logger.error(f"Error emptying S3 bucket '{bucket_name}' (Resource: {logical_id}): {e}", exc_info=True); raise
+    except Exception as e: logger.error(f"Error emptying S3 bucket '{bucket_name}' (Resource: {logical_id}): {e}", exc_info=True); raise
+
+def delete_ecr_repository_images(ecr_client, repository_name, logical_id="N/A", dry_run=False): # Added dry_run
+    logger.info(f"Processing ECR repository: {repository_name} (Resource: {logical_id})")
+    if dry_run:
+        logger.info(f"[DRY RUN] Would delete images from ECR repository: {repository_name} (Resource: {logical_id}).")
+        return
+    try:
+        image_ids = []
+        paginator = ecr_client.get_paginator('list_images')
+        logger.debug(f"Listing images in {repository_name}...")
+        for page in paginator.paginate(repositoryName=repository_name):
+            if 'imageIds' in page: image_ids.extend(page['imageIds'])
+        if not image_ids: logger.info(f"ECR repository '{repository_name}' is already empty (Resource: {logical_id})."); return
+
+        logger.info(f"Found {len(image_ids)} images to delete in {repository_name}.")
+        for i in range(0, len(image_ids), 100):
+            chunk = image_ids[i:i + 100]
+            logger.debug(f"Deleting batch of {len(chunk)} images from '{repository_name}'...")
+            ecr_client.batch_delete_image(repositoryName=repository_name, imageIds=chunk)
+        logger.info(f"Successfully deleted all images from ECR repository: {repository_name} (Resource: {logical_id}).")
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'RepositoryNotFoundException': logger.warning(f"ECR repository '{repository_name}' not found (Resource: {logical_id}).")
+        else: logger.error(f"Error deleting images from ECR repository '{repository_name}' (Resource: {logical_id}): {e}", exc_info=True); raise
+    except Exception as e: logger.error(f"Error deleting images from ECR repository '{repository_name}' (Resource: {logical_id}): {e}", exc_info=True); raise
+
+if __name__ == "__main__":
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the 'tests' directory as a package.

--- a/tests/test_cfn_stack_deleter.py
+++ b/tests/test_cfn_stack_deleter.py
@@ -1,0 +1,646 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+import argparse
+import json
+import os # For a few os-related mocks if needed, and for `os.path.exists`
+import sys
+
+# Add project root to sys.path to allow importing cfn_stack_deleter
+# This assumes the test is run from the project root directory or tests/ directory.
+# A more robust solution might involve setting PYTHONPATH or using a proper package structure.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import cfn_stack_deleter # Import the script to be tested
+
+class TestArgParsing(unittest.TestCase):
+    def test_required_args(self):
+        args = cfn_stack_deleter.parse_arguments(['--stack-name', 'test-stack', '--region', 'us-east-1'])
+        self.assertEqual(args.stack_name, 'test-stack')
+        self.assertEqual(args.region, 'us-east-1')
+        self.assertFalse(args.dry_run) # Default
+        self.assertIsNone(args.profile)
+        self.assertIsNone(args.role_arn)
+        self.assertEqual(args.role_session_name, "CfnStackDeleterSession") # Default
+
+    def test_dry_run(self):
+        args = cfn_stack_deleter.parse_arguments(['--stack-name', 's', '--region', 'r', '--dry-run'])
+        self.assertTrue(args.dry_run)
+
+    def test_profile(self):
+        args = cfn_stack_deleter.parse_arguments(['--stack-name', 's', '--region', 'r', '--profile', 'myprof'])
+        self.assertEqual(args.profile, 'myprof')
+
+    def test_role_arn(self):
+        args = cfn_stack_deleter.parse_arguments(['--stack-name', 's', '--region', 'r', '--role-arn', 'myarn'])
+        self.assertEqual(args.role_arn, 'myarn')
+
+    def test_role_session_name(self):
+        args = cfn_stack_deleter.parse_arguments(['--stack-name', 's', '--region', 'r', '--role-session-name', 'customsession'])
+        self.assertEqual(args.role_session_name, 'customsession')
+
+    def test_missing_required_args(self):
+        # Test that argparse raises SystemExit if required args are missing
+        with self.assertRaises(SystemExit):
+            cfn_stack_deleter.parse_arguments(['--region', 'us-east-1'])
+        with self.assertRaises(SystemExit):
+            cfn_stack_deleter.parse_arguments(['--stack-name', 'test-stack'])
+
+class TestStateManagement(unittest.TestCase):
+    def setUp(self):
+        self.stack_name = "test-stack"
+        self.stack_id = "sid-123"
+        self.resources = [{"LogicalResourceId": "Res1", "PhysicalResourceId": "Phys1"}]
+        self.state_filename = cfn_stack_deleter.get_state_filename(self.stack_name)
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('cfn_stack_deleter.datetime') # Mock datetime to control timestamp
+    def test_save_state_success(self, mock_datetime, mock_file_open):
+        mock_datetime.utcnow.return_value.isoformat.return_value = "2023-01-01T12:00:00"
+        cfn_stack_deleter.save_state(self.stack_name, self.stack_id, self.resources, dry_run=False)
+
+        mock_file_open.assert_called_once_with(self.state_filename, 'w')
+        handle = mock_file_open()
+
+        # Check what was written to the file
+        # json.dump(data, handle, indent=2)
+        # The first call to write is the data itself, or a part of it.
+        # We need to ensure json.dump was called with the correct structure.
+        # Since json.dump might write in chunks, we check the call to json.dump itself.
+
+        # For simplicity, let's assume json.dump is called once by mock_open's handle context manager.
+        # A more robust way is to patch json.dump directly.
+
+        # Patching json.dump for verification
+        with patch('json.dump') as mock_json_dump:
+             cfn_stack_deleter.save_state(self.stack_name, self.stack_id, self.resources, dry_run=False)
+             expected_state = {
+                "stack_name": self.stack_name,
+                "stack_id": self.stack_id,
+                "last_saved_utc": "2023-01-01T12:00:00",
+                "resources": self.resources
+            }
+             mock_json_dump.assert_called_once_with(expected_state, mock_file_open(), indent=2)
+
+
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open, read_data='{"stack_name": "test-stack", "resources": []}')
+    def test_load_state_success(self, mock_file_open, mock_exists):
+        state = cfn_stack_deleter.load_state(self.stack_name)
+        mock_exists.assert_called_once_with(self.state_filename)
+        mock_file_open.assert_called_once_with(self.state_filename, 'r')
+        self.assertEqual(state['stack_name'], 'test-stack')
+
+    @patch('os.path.exists', return_value=False)
+    def test_load_state_not_found(self, mock_exists):
+        state = cfn_stack_deleter.load_state(self.stack_name)
+        mock_exists.assert_called_once_with(self.state_filename)
+        self.assertIsNone(state)
+
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open, read_data='this is not json')
+    def test_load_state_corrupted_json(self, mock_file_open, mock_exists):
+        state = cfn_stack_deleter.load_state(self.stack_name)
+        self.assertIsNone(state) # Should return None on JSONDecodeError
+
+    @patch('os.path.exists', return_value=True)
+    @patch('shutil.move') # shutil.move is used in backup_state_file
+    @patch('cfn_stack_deleter.datetime')
+    def test_backup_state_file(self, mock_datetime_os, mock_shutil_move, mock_os_exists):
+        mock_now = MagicMock()
+        mock_datetime_os.now.return_value = mock_now
+        mock_now.strftime.return_value = "20230101120000"
+
+        cfn_stack_deleter.backup_state_file(self.stack_name, dry_run=False)
+
+        expected_backup_filename = f"{self.state_filename}.20230101120000.bak"
+        mock_os_exists.assert_called_once_with(self.state_filename)
+        mock_shutil_move.assert_called_once_with(self.state_filename, expected_backup_filename)
+
+    @patch('builtins.open', new_callable=mock_open)
+    def test_save_state_dry_run(self, mock_file_open):
+        # Test that save_state in dry_run mode does not open/write any file
+        cfn_stack_deleter.save_state(self.stack_name, self.stack_id, self.resources, dry_run=True)
+        mock_file_open.assert_not_called()
+
+    @patch('shutil.move')
+    def test_backup_state_file_dry_run(self, mock_shutil_move):
+        # Test that backup_state_file in dry_run mode does not move any file
+        cfn_stack_deleter.backup_state_file(self.stack_name, dry_run=True)
+        mock_shutil_move.assert_not_called()
+
+
+class TestLoggingSetup(unittest.TestCase):
+    @patch('logging.FileHandler')
+    @patch('logging.StreamHandler')
+    @patch('logging.getLogger') # Patch getLogger to inspect the one used by the script
+    def test_setup_logging_basic(self, mock_getLogger, mock_StreamHandler, mock_FileHandler):
+        # Mock the logger instance that will be returned by getLogger
+        mock_logger_instance = MagicMock()
+        mock_getLogger.return_value = mock_logger_instance
+
+        cfn_stack_deleter.setup_logging("test_stack_log", is_dry_run=False)
+
+        mock_getLogger.assert_called_with("CfnStackDeleter")
+        mock_logger_instance.setLevel.assert_called_with(logging.DEBUG)
+
+        self.assertTrue(any(isinstance(call_args[0][0], logging.StreamHandler) for call_args in mock_logger_instance.addHandler.call_args_list))
+        self.assertTrue(any(isinstance(call_args[0][0], logging.FileHandler) for call_args in mock_logger_instance.addHandler.call_args_list))
+
+        # Check if FileHandler was called with a path containing the stack name
+        mock_FileHandler.assert_called()
+        args, kwargs = mock_FileHandler.call_args
+        self.assertIn("test_stack_log", args[0])
+
+
+    @patch('logging.Formatter') # To check formatter string for dry run
+    @patch('logging.getLogger')
+    def test_setup_logging_dry_run_formatter(self, mock_getLogger, mock_Formatter):
+        mock_logger_instance = MagicMock()
+        mock_getLogger.return_value = mock_logger_instance
+
+        # Need to capture the handler to check its formatter
+        # Mock addHandler to get the handler instance
+        mock_stream_handler_instance = MagicMock(spec=logging.StreamHandler)
+        mock_file_handler_instance = MagicMock(spec=logging.FileHandler)
+
+        def side_effect_add_handler(handler):
+            if isinstance(handler, logging.StreamHandler):
+                handler.setFormatter = MagicMock() # Mock setFormatter on the instance
+            elif isinstance(handler, logging.FileHandler):
+                 handler.setFormatter = MagicMock()
+
+        mock_logger_instance.addHandler = MagicMock(side_effect=side_effect_add_handler)
+
+        with patch('logging.StreamHandler', return_value=mock_stream_handler_instance), \
+             patch('logging.FileHandler', return_value=mock_file_handler_instance):
+            cfn_stack_deleter.setup_logging("test_stack_log_dry", is_dry_run=True)
+
+        # Check that Formatter was called with a string starting with [DRY RUN] for StreamHandler
+        # This is a bit complex due to how formatters are set.
+        # A simpler check might be on the formatter string passed to Formatter constructor.
+
+        # mock_Formatter.assert_any_call(unittest.mock.ANY) # Ensure Formatter was called
+        # Check if any call to Formatter had a dry run string
+        dry_run_formatter_called_for_console = False
+        for call in mock_Formatter.call_args_list:
+            args, kwargs = call
+            if args and args[0].startswith('[DRY RUN] %(asctime)s - %(levelname)s - %(message)s'):
+                dry_run_formatter_called_for_console = True
+                break
+        self.assertTrue(dry_run_formatter_called_for_console, "Dry run formatter for console not found.")
+
+
+class TestAWSMockingDemonstration(unittest.TestCase): # Renamed for clarity
+    @patch('boto3.Session')
+    def test_boto3_session_mocking_example(self, MockSession): # Renamed for clarity
+        # Configure the mock session and its client
+        mock_cfn_client = MagicMock()
+        mock_session_instance = MockSession.return_value
+        mock_session_instance.client.return_value = mock_cfn_client
+
+        # Example: Mocking describe_stacks
+        mock_cfn_client.describe_stacks.return_value = {
+            "Stacks": [{"StackName": "test-stack", "StackStatus": "CREATE_COMPLETE", "StackId": "arn:..."}]
+        }
+
+        # In a real test, you would call a function from cfn_stack_deleter
+        # that uses boto3.Session() and cfn_client.describe_stacks().
+        # This test is primarily to show how patching boto3.Session works.
+
+        # Example usage within the test (not calling external code here)
+        session_instance = MockSession.return_value # Get the instance of the session
+        cfn_mock = MagicMock()
+        session_instance.client.return_value = cfn_mock # Make session.client('cloudformation') return our cfn_mock
+
+        cfn_mock.describe_stacks.return_value = {"Stacks": [{"StackId": "id-123"}]}
+
+        # Simulate calling some code that would use this session
+        # For instance, if cfn_stack_deleter.some_function_using_session() existed:
+        # cfn_stack_deleter.some_function_using_session()
+
+        # Assertions:
+        # MockSession.assert_called_once() # If session was expected to be created once
+        # session_instance.client.assert_called_with('cloudformation')
+        # cfn_mock.describe_stacks.assert_called_with(StackName='some_stack')
+        self.assertTrue(True) # Placeholder as this is a demo
+
+
+class TestResourceHandlers(unittest.TestCase):
+    def setUp(self):
+        self.mock_clients = {
+            's3': MagicMock(),
+            'ecr': MagicMock(),
+            'ec2': MagicMock(),
+            'iam': MagicMock(),
+            'cfn': MagicMock()
+        }
+        self.stack_name = "test-stack"
+        self.region = "us-east-1"
+        self.account_id = "123456789012"
+        self.mock_logger_patch = patch('cfn_stack_deleter.logger') # Patch the logger used by the script
+        self.mock_logger = self.mock_logger_patch.start()
+        self.addCleanup(self.mock_logger_patch.stop)
+
+
+    # --- Test handle_s3_bucket (which calls empty_s3_bucket) ---
+    def test_handle_s3_bucket_empty(self):
+        mock_s3 = self.mock_clients['s3']
+        resource_details = {'LogicalResourceId': 'MyBucket', 'PhysicalResourceId': 'bucket-123', 'ResourceType': 'AWS::S3::Bucket'}
+
+        # Paginate returns an iterable, first item is a page, which is a dict
+        mock_s3.get_paginator.return_value.paginate.return_value = [{'Versions': [], 'DeleteMarkers': []}]
+
+        cfn_stack_deleter.handle_s3_bucket(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_s3.get_paginator.assert_called_once_with('list_object_versions')
+        mock_s3.get_paginator.return_value.paginate.assert_called_once_with(Bucket='bucket-123')
+        mock_s3.delete_objects.assert_not_called() # No objects to delete
+        self.mock_logger.info.assert_any_call("Successfully emptied S3 bucket: bucket-123 (0 objects/versions deleted).")
+
+
+    def test_handle_s3_bucket_with_objects(self):
+        mock_s3 = self.mock_clients['s3']
+        resource_details = {'LogicalResourceId': 'MyBucket', 'PhysicalResourceId': 'bucket-123', 'ResourceType': 'AWS::S3::Bucket'}
+
+        mock_s3.get_paginator.return_value.paginate.return_value = [
+            {'Versions': [{'Key': 'obj1', 'VersionId': 'v1'}]},
+            {'DeleteMarkers': [{'Key': 'obj2', 'VersionId': 'v2del'}]}
+        ]
+
+        cfn_stack_deleter.handle_s3_bucket(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_s3.delete_objects.assert_called_once_with(Bucket='bucket-123', Delete={'Objects': [{'Key': 'obj1', 'VersionId': 'v1'}, {'Key': 'obj2', 'VersionId': 'v2del'}]})
+        self.mock_logger.info.assert_any_call("Successfully emptied S3 bucket: bucket-123 (2 objects/versions deleted).")
+
+    def test_handle_s3_bucket_no_such_bucket(self):
+        mock_s3 = self.mock_clients['s3']
+        resource_details = {'LogicalResourceId': 'MyBucket', 'PhysicalResourceId': 'bucket-123', 'ResourceType': 'AWS::S3::Bucket'}
+
+        mock_s3.get_paginator.return_value.paginate.side_effect = botocore.exceptions.ClientError({'Error': {'Code': 'NoSuchBucket', 'Message': 'Not Found'}}, 'ListObjectVersions')
+
+        # empty_s3_bucket should catch this and log, not raise to handler for this specific error
+        cfn_stack_deleter.handle_s3_bucket(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.warning.assert_any_call("S3 bucket 'bucket-123' not found (Resource: MyBucket).")
+
+    def test_handle_s3_bucket_dry_run(self):
+        mock_s3 = self.mock_clients['s3']
+        resource_details = {'LogicalResourceId': 'MyBucket', 'PhysicalResourceId': 'bucket-123', 'ResourceType': 'AWS::S3::Bucket'}
+
+        cfn_stack_deleter.handle_s3_bucket(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=True)
+
+        mock_s3.get_paginator.assert_not_called() # empty_s3_bucket should check dry_run first
+        mock_s3.delete_objects.assert_not_called()
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would empty S3 bucket: bucket-123 (Resource: MyBucket).")
+
+
+    # --- Test handle_ecr_repository (which calls delete_ecr_repository_images) ---
+    def test_handle_ecr_repo_empty(self):
+        mock_ecr = self.mock_clients['ecr']
+        resource_details = {'LogicalResourceId': 'MyRepo', 'PhysicalResourceId': 'repo-name', 'ResourceType': 'AWS::ECR::Repository'}
+        mock_ecr.get_paginator.return_value.paginate.return_value = [{'imageIds': []}]
+
+        cfn_stack_deleter.handle_ecr_repository(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        mock_ecr.batch_delete_image.assert_not_called()
+        self.mock_logger.info.assert_any_call("ECR repository 'repo-name' is already empty (Resource: MyRepo).")
+
+    def test_handle_ecr_repo_with_images(self):
+        mock_ecr = self.mock_clients['ecr']
+        resource_details = {'LogicalResourceId': 'MyRepo', 'PhysicalResourceId': 'repo-name', 'ResourceType': 'AWS::ECR::Repository'}
+        images = [{'imageDigest': 'sha256:123'}, {'imageDigest': 'sha256:456'}]
+        mock_ecr.get_paginator.return_value.paginate.return_value = [{'imageIds': images}]
+
+        cfn_stack_deleter.handle_ecr_repository(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        mock_ecr.batch_delete_image.assert_called_once_with(repositoryName='repo-name', imageIds=images)
+        self.mock_logger.info.assert_any_call("Successfully deleted all images from ECR repository: repo-name (Resource: MyRepo).")
+
+    def test_handle_ecr_repo_not_found(self):
+        mock_ecr = self.mock_clients['ecr']
+        resource_details = {'LogicalResourceId': 'MyRepo', 'PhysicalResourceId': 'repo-name', 'ResourceType': 'AWS::ECR::Repository'}
+        mock_ecr.get_paginator.return_value.paginate.side_effect = botocore.exceptions.ClientError({'Error': {'Code': 'RepositoryNotFoundException', 'Message': 'Not Found'}}, 'ListImages')
+
+        cfn_stack_deleter.handle_ecr_repository(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.warning.assert_any_call("ECR repository 'repo-name' not found (Resource: MyRepo).")
+
+    def test_handle_ecr_repo_dry_run(self):
+        mock_ecr = self.mock_clients['ecr']
+        resource_details = {'LogicalResourceId': 'MyRepo', 'PhysicalResourceId': 'repo-name', 'ResourceType': 'AWS::ECR::Repository'}
+
+        cfn_stack_deleter.handle_ecr_repository(self.mock_clients, resource_details, [], self.stack_name, self.region, self.account_id, dry_run=True)
+        mock_ecr.get_paginator.assert_not_called()
+        mock_ecr.batch_delete_image.assert_not_called()
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would delete images from ECR repository: repo-name (Resource: MyRepo).")
+
+
+    # --- Test handle_ec2_instance ---
+    @patch('cfn_stack_deleter.time.sleep', return_value=None) # Mock time.sleep if used by waiters
+    def test_handle_ec2_instance_terminates(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyEC2', 'PhysicalResourceId': 'i-123', 'ResourceType': 'AWS::EC2::Instance'}
+
+        mock_ec2.describe_instances.return_value = {'Reservations': [{'Instances': [{'InstanceId': 'i-123', 'State': {'Name': 'running'}}]}]}
+        mock_ec2.describe_instance_attribute.return_value = {'DisableApiTermination': {'Value': False}} # Not protected
+
+        cfn_stack_deleter.handle_ec2_instance(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_ec2.describe_instances.assert_called_with(InstanceIds=['i-123'])
+        mock_ec2.describe_instance_attribute.assert_called_with(InstanceId='i-123', Attribute='disableApiTermination')
+        mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=['i-123'])
+        self.mock_logger.info.assert_any_call("Termination for i-123 (MyEC2) submitted.")
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_instance_termination_protected(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyEC2', 'PhysicalResourceId': 'i-123', 'ResourceType': 'AWS::EC2::Instance'}
+
+        mock_ec2.describe_instances.return_value = {'Reservations': [{'Instances': [{'InstanceId': 'i-123', 'State': {'Name': 'running'}}]}]}
+        mock_ec2.describe_instance_attribute.return_value = {'DisableApiTermination': {'Value': True}} # IS protected
+
+        cfn_stack_deleter.handle_ec2_instance(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_ec2.modify_instance_attribute.assert_called_once_with(InstanceId='i-123', DisableApiTermination={'Value': False})
+        mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=['i-123'])
+        self.mock_logger.info.assert_any_call("Disabling termination protection for i-123 (MyEC2)...")
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_instance_already_terminated(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyEC2', 'PhysicalResourceId': 'i-123', 'ResourceType': 'AWS::EC2::Instance'}
+        mock_ec2.describe_instances.return_value = {'Reservations': [{'Instances': [{'InstanceId': 'i-123', 'State': {'Name': 'terminated'}}]}]}
+
+        cfn_stack_deleter.handle_ec2_instance(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        mock_ec2.terminate_instances.assert_not_called()
+        self.mock_logger.info.assert_any_call("Instance i-123 (MyEC2) already terminated. Skip.")
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_instance_not_found(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyEC2', 'PhysicalResourceId': 'i-123', 'ResourceType': 'AWS::EC2::Instance'}
+        mock_ec2.describe_instances.side_effect = botocore.exceptions.ClientError({'Error': {'Code': 'InvalidInstanceID.NotFound', 'Message': 'Not Found'}}, 'DescribeInstances')
+
+        cfn_stack_deleter.handle_ec2_instance(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.warning.assert_any_call("EC2 Instance i-123 (MyEC2) not found.")
+        mock_ec2.terminate_instances.assert_not_called()
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_instance_dry_run(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyEC2', 'PhysicalResourceId': 'i-123', 'ResourceType': 'AWS::EC2::Instance'}
+        mock_ec2.describe_instances.return_value = {'Reservations': [{'Instances': [{'InstanceId': 'i-123', 'State': {'Name': 'running'}}]}]} # Still need to describe for logging
+
+        cfn_stack_deleter.handle_ec2_instance(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=True)
+        mock_ec2.modify_instance_attribute.assert_not_called()
+        mock_ec2.terminate_instances.assert_not_called()
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would check and disable termination protection if enabled for i-123 (MyEC2).")
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would terminate instance i-123 (MyEC2).")
+
+    # --- Test handle_ec2_volume ---
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_volume_deletes_available(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyVol', 'PhysicalResourceId': 'vol-123', 'ResourceType': 'AWS::EC2::Volume'}
+        mock_ec2.describe_volumes.return_value = {'Volumes': [{'VolumeId': 'vol-123', 'State': 'available', 'Attachments': []}]}
+
+        cfn_stack_deleter.handle_ec2_volume(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        mock_ec2.detach_volume.assert_not_called()
+        mock_ec2.delete_volume.assert_called_once_with(VolumeId='vol-123')
+        self.mock_logger.info.assert_any_call("Deletion for vol-123 (MyVol) submitted.")
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_volume_detaches_then_deletes(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyVol', 'PhysicalResourceId': 'vol-123', 'ResourceType': 'AWS::EC2::Volume'}
+
+        # Initial describe_volumes call
+        mock_ec2.describe_volumes.side_effect = [
+            {'Volumes': [{'VolumeId': 'vol-123', 'State': 'in-use', 'Attachments': [{'InstanceId': 'i-abc', 'Device': '/dev/sdf'}]}]}, # First call: in-use
+            # Subsequent calls for waiter or re-check can be mocked if waiter logic is very specific
+            # For this test, assume waiter will eventually see it as 'available'
+        ]
+
+        # Mock waiter if used explicitly, or assume detach works and then describe shows available
+        mock_waiter = MagicMock()
+        mock_ec2.get_waiter.return_value = mock_waiter
+
+        # After detach, volume becomes available
+        def describe_volumes_after_detach(*args, **kwargs):
+            if kwargs.get('VolumeIds') == ['vol-123']: # Check if it's the describe call we expect
+                 return {'Volumes': [{'VolumeId': 'vol-123', 'State': 'available', 'Attachments': []}]}
+            return MagicMock() # Default for other calls if any
+
+        # We need to ensure that after detach_volume is called, the next describe_volumes shows 'available'
+        # This is tricky with side_effect list if waiter makes multiple calls.
+        # Simpler: assume detach works and then we just check delete.
+        # The waiter itself calls describe_volumes repeatedly.
+
+        cfn_stack_deleter.handle_ec2_volume(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_ec2.detach_volume.assert_called_once_with(VolumeId='vol-123') # Default Force=False is fine
+        mock_ec2.get_waiter.assert_called_once_with('volume_available')
+        mock_waiter.wait.assert_called_once_with(VolumeIds=['vol-123'], WaiterConfig={'Delay': 10, 'MaxAttempts': 30})
+        mock_ec2.delete_volume.assert_called_once_with(VolumeId='vol-123')
+        self.mock_logger.info.assert_any_call("Volume vol-123 (MyVol) is now available.")
+
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_volume_already_deleted(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyVol', 'PhysicalResourceId': 'vol-123', 'ResourceType': 'AWS::EC2::Volume'}
+        mock_ec2.describe_volumes.return_value = {'Volumes': [{'VolumeId': 'vol-123', 'State': 'deleted'}]}
+
+        cfn_stack_deleter.handle_ec2_volume(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        mock_ec2.delete_volume.assert_not_called()
+        self.mock_logger.info.assert_any_call("Volume vol-123 (MyVol) already deleted. Skip.")
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_volume_not_found(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyVol', 'PhysicalResourceId': 'vol-123', 'ResourceType': 'AWS::EC2::Volume'}
+        mock_ec2.describe_volumes.side_effect = botocore.exceptions.ClientError({'Error': {'Code': 'InvalidVolume.NotFound', 'Message': 'Not Found'}}, 'DescribeVolumes')
+
+        cfn_stack_deleter.handle_ec2_volume(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.warning.assert_any_call("EC2 Volume vol-123 (MyVol) not found.")
+        mock_ec2.delete_volume.assert_not_called()
+
+    @patch('cfn_stack_deleter.time.sleep', return_value=None)
+    def test_handle_ec2_volume_dry_run(self, mock_sleep):
+        mock_ec2 = self.mock_clients['ec2']
+        res_details = {'LogicalResourceId': 'MyVol', 'PhysicalResourceId': 'vol-123', 'ResourceType': 'AWS::EC2::Volume'}
+        # Simulate volume is in-use to test both detach and delete dry run logs
+        mock_ec2.describe_volumes.return_value = {'Volumes': [{'VolumeId': 'vol-123', 'State': 'in-use', 'Attachments': [{'InstanceId': 'i-abc'}]}]}
+
+        cfn_stack_deleter.handle_ec2_volume(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=True)
+        mock_ec2.detach_volume.assert_not_called()
+        mock_ec2.delete_volume.assert_not_called()
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would detach volume vol-123 (MyVol) from i-abc.")
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would delete volume vol-123 (MyVol).")
+
+
+    # --- Test handle_iam_role ---
+    def test_handle_iam_role_simple_delete(self):
+        mock_iam = self.mock_clients['iam']
+        res_details = {'LogicalResourceId': 'MyRole', 'PhysicalResourceId': 'my-role-name', 'ResourceType': 'AWS::IAM::Role'}
+
+        # Simulate role exists, has no attached/inline policies, no instance profiles
+        mock_iam.get_role.return_value = {'Role': {'RoleName': 'my-role-name'}} # Exists
+        mock_iam.get_paginator.side_effect = lambda PaginatorName: MagicMock(paginate=MagicMock(return_value=[])) # No items for any paginator
+
+        cfn_stack_deleter.handle_iam_role(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_iam.get_role.assert_called_once_with(RoleName='my-role-name')
+        mock_iam.delete_role.assert_called_once_with(RoleName='my-role-name')
+        self.mock_logger.info.assert_any_call("IAM role my-role-name (MyRole) deleted.")
+
+    def test_handle_iam_role_with_policies_and_profile(self):
+        mock_iam = self.mock_clients['iam']
+        res_details = {'LogicalResourceId': 'MyRole', 'PhysicalResourceId': 'arn:aws:iam::123:role/complex-role', 'ResourceType': 'AWS::IAM::Role'}
+
+        mock_iam.get_role.return_value = {'Role': {'RoleName': 'complex-role'}}
+
+        # Mock paginators
+        mock_list_attached_policies_pager = MagicMock()
+        mock_list_attached_policies_pager.paginate.return_value = [{'AttachedPolicies': [{'PolicyArn': 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'}]}]
+
+        mock_list_role_policies_pager = MagicMock()
+        mock_list_role_policies_pager.paginate.return_value = [{'PolicyNames': ['my-inline-policy']}]
+
+        mock_list_instance_profiles_pager = MagicMock()
+        mock_list_instance_profiles_pager.paginate.return_value = [{'InstanceProfiles': [{'InstanceProfileName': 'my-instance-profile'}]}]
+
+        def paginator_side_effect(PaginatorName):
+            if PaginatorName == 'list_attached_role_policies': return mock_list_attached_policies_pager
+            if PaginatorName == 'list_role_policies': return mock_list_role_policies_pager
+            if PaginatorName == 'list_instance_profiles_for_role': return mock_list_instance_profiles_pager
+            return MagicMock(paginate=MagicMock(return_value=[])) # Default for others
+        mock_iam.get_paginator.side_effect = paginator_side_effect
+
+        cfn_stack_deleter.handle_iam_role(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+
+        mock_iam.detach_role_policy.assert_called_once_with(RoleName='complex-role', PolicyArn='arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess')
+        mock_iam.delete_role_policy.assert_called_once_with(RoleName='complex-role', PolicyName='my-inline-policy')
+        mock_iam.remove_role_from_instance_profile.assert_called_once_with(InstanceProfileName='my-instance-profile', RoleName='complex-role')
+        mock_iam.delete_role.assert_called_once_with(RoleName='complex-role')
+
+    def test_handle_iam_role_not_found(self):
+        mock_iam = self.mock_clients['iam']
+        res_details = {'LogicalResourceId': 'MyRole', 'PhysicalResourceId': 'my-role-name', 'ResourceType': 'AWS::IAM::Role'}
+        mock_iam.get_role.side_effect = mock_iam.exceptions.NoSuchEntityException({'Error': {'Code': 'NoSuchEntity', 'Message': 'Not Found'}}, 'GetRole')
+
+        cfn_stack_deleter.handle_iam_role(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.warning.assert_any_call("IAM Role my-role-name (MyRole) not found.")
+        mock_iam.delete_role.assert_not_called()
+
+    def test_handle_iam_role_delete_conflict(self):
+        mock_iam = self.mock_clients['iam']
+        res_details = {'LogicalResourceId': 'MyRole', 'PhysicalResourceId': 'my-role-name', 'ResourceType': 'AWS::IAM::Role'}
+        mock_iam.get_role.return_value = {'Role': {'RoleName': 'my-role-name'}}
+        mock_iam.get_paginator.side_effect = lambda PaginatorName: MagicMock(paginate=MagicMock(return_value=[]))
+        mock_iam.delete_role.side_effect = mock_iam.exceptions.DeleteConflictException({'Error': {'Code': 'DeleteConflict', 'Message': 'Conflict'}}, 'DeleteRole')
+
+        with self.assertRaises(botocore.exceptions.ClientError): # Expecting it to re-raise
+             cfn_stack_deleter.handle_iam_role(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.error.assert_any_call("IAM Role my-role-name (MyRole) delete conflict: An error occurred (DeleteConflict) when calling the DeleteRole operation: Conflict. Might be in use.", exc_info=True)
+
+
+    def test_handle_iam_role_dry_run(self):
+        mock_iam = self.mock_clients['iam']
+        res_details = {'LogicalResourceId': 'MyRole', 'PhysicalResourceId': 'my-role-name', 'ResourceType': 'AWS::IAM::Role'}
+        mock_iam.get_role.return_value = {'Role': {'RoleName': 'my-role-name'}} # Role needs to "exist" for dry run to list things
+
+        cfn_stack_deleter.handle_iam_role(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=True)
+
+        mock_iam.detach_role_policy.assert_not_called()
+        mock_iam.delete_role_policy.assert_not_called()
+        mock_iam.remove_role_from_instance_profile.assert_not_called()
+        mock_iam.delete_role.assert_not_called()
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would list and detach managed policies from my-role-name (MyRole).")
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would list and delete inline policies from my-role-name (MyRole).")
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would list and remove role my-role-name (MyRole) from instance profiles.")
+        self.mock_logger.info.assert_any_call("[DRY RUN] Would delete IAM role my-role-name (MyRole).")
+
+
+    # --- Test handle_iam_policy ---
+    def test_handle_iam_policy_aws_managed_skipped(self):
+        mock_iam = self.mock_clients['iam']
+        res_details = {'LogicalResourceId': 'MyManagedPolicy', 'PhysicalResourceId': 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess', 'ResourceType': 'AWS::IAM::Policy'}
+
+        cfn_stack_deleter.handle_iam_policy(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.info.assert_any_call("Policy arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess (MyManagedPolicy) is AWS managed. Skip.")
+        mock_iam.get_policy.assert_not_called() # Should skip before this
+
+    def test_handle_iam_policy_not_found(self):
+        mock_iam = self.mock_clients['iam']
+        policy_arn = f'arn:aws:iam::{self.account_id}:policy/MyCustomPolicy'
+        res_details = {'LogicalResourceId': 'MyCustomPolicy', 'PhysicalResourceId': policy_arn, 'ResourceType': 'AWS::IAM::Policy'}
+        mock_iam.get_policy.side_effect = mock_iam.exceptions.NoSuchEntityException({'Error': {'Code': 'NoSuchEntity', 'Message': 'Not Found'}}, 'GetPolicy')
+
+        cfn_stack_deleter.handle_iam_policy(self.mock_clients, res_details, [], self.stack_name, self.region, self.account_id, dry_run=False)
+        self.mock_logger.warning.assert_any_call(f"IAM Policy {policy_arn} (MyCustomPolicy) not found.")
+        mock_iam.list_entities_for_policy.assert_not_called()
+
+    def test_handle_iam_policy_detach_from_stack_roles(self):
+        mock_iam = self.mock_clients['iam']
+        policy_arn = f'arn:aws:iam::{self.account_id}:policy/MyCustomPolicy'
+        res_details = {'LogicalResourceId': 'MyPol', 'PhysicalResourceId': policy_arn, 'ResourceType': 'AWS::IAM::Policy'}
+
+        # Simulate stack_resources_list containing roles
+        stack_resources = [
+            {'ResourceType': 'AWS::IAM::Role', 'PhysicalResourceId': 'stack-role-1'},
+            {'ResourceType': 'AWS::IAM::Role', 'PhysicalResourceId': 'arn:aws:iam::123:role/stack-role-2'}, # Test ARN parsing for roles too
+            {'ResourceType': 'AWS::S3::Bucket', 'PhysicalResourceId': 'some-bucket'} # Other resource
+        ]
+
+        mock_iam.get_policy.return_value = {'Policy': {'Arn': policy_arn, 'AttachmentCount': 2}}
+
+        # Simulate policy attached to stack-role-1, stack-role-2 and an external role
+        mock_entities_pager = MagicMock()
+        mock_entities_pager.paginate.return_value = [{'PolicyRoles': [
+            {'RoleName': 'stack-role-1'},
+            {'RoleName': 'stack-role-2'},
+            {'RoleName': 'external-role'}
+        ]}]
+        mock_iam.get_paginator.return_value = mock_entities_pager
+
+        cfn_stack_deleter.handle_iam_policy(self.mock_clients, res_details, stack_resources, self.stack_name, self.region, self.account_id, dry_run=False)
+
+        # Assert detach called only for stack roles
+        mock_iam.detach_role_policy.assert_any_call(RoleName='stack-role-1', PolicyArn=policy_arn)
+        mock_iam.detach_role_policy.assert_any_call(RoleName='stack-role-2', PolicyArn=policy_arn)
+        # Assert NOT called for external-role
+        calls = mock_iam.detach_role_policy.call_args_list
+        self.assertFalse(any(call.kwargs.get('RoleName') == 'external-role' for call in calls))
+        self.assertEqual(mock_iam.detach_role_policy.call_count, 2)
+        self.mock_logger.info.assert_any_call(f"Detached {policy_arn} (MyPol) from 2 stack roles.")
+
+    def test_handle_iam_policy_no_stack_roles_attached(self):
+        mock_iam = self.mock_clients['iam']
+        policy_arn = f'arn:aws:iam::{self.account_id}:policy/MyCustomPolicy'
+        res_details = {'LogicalResourceId': 'MyPol', 'PhysicalResourceId': policy_arn, 'ResourceType': 'AWS::IAM::Policy'}
+        stack_resources = [{'ResourceType': 'AWS::IAM::Role', 'PhysicalResourceId': 'some-other-stack-role'}] # A role not attached
+
+        mock_iam.get_policy.return_value = {'Policy': {'Arn': policy_arn, 'AttachmentCount': 1}}
+        mock_entities_pager = MagicMock()
+        mock_entities_pager.paginate.return_value = [{'PolicyRoles': [{'RoleName': 'external-role'}]}]
+        mock_iam.get_paginator.return_value = mock_entities_pager
+
+        cfn_stack_deleter.handle_iam_policy(self.mock_clients, res_details, stack_resources, self.stack_name, self.region, self.account_id, dry_run=False)
+        mock_iam.detach_role_policy.assert_not_called()
+        self.mock_logger.debug.assert_any_call(f"Policy {policy_arn} (MyPol) not found attached to any identified stack roles.")
+
+
+    def test_handle_iam_policy_dry_run(self):
+        mock_iam = self.mock_clients['iam']
+        policy_arn = f'arn:aws:iam::{self.account_id}:policy/MyCustomPolicy'
+        res_details = {'LogicalResourceId': 'MyPol', 'PhysicalResourceId': policy_arn, 'ResourceType': 'AWS::IAM::Policy'}
+        stack_resources = [{'ResourceType': 'AWS::IAM::Role', 'PhysicalResourceId': 'stack-role-1'}]
+
+        mock_iam.get_policy.return_value = {'Policy': {'Arn': policy_arn, 'AttachmentCount': 1}} # Policy needs to "exist"
+
+        cfn_stack_deleter.handle_iam_policy(self.mock_clients, res_details, stack_resources, self.stack_name, self.region, self.account_id, dry_run=True)
+
+        mock_iam.list_entities_for_policy.assert_not_called() # Should be skipped in dry_run after initial log
+        mock_iam.detach_role_policy.assert_not_called()
+        self.mock_logger.info.assert_any_call(f"[DRY RUN] Would list entities for policy {policy_arn} (MyPol) and detach from stack-specific roles: {{'stack-role-1'}}.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a Python script, `cfn_stack_deleter.py`, designed to assist you in forcibly deleting AWS CloudFormation stacks.

Key features include:
- Pre-emptive deletion/cleanup of common blocking resources:
    - S3 Buckets (emptying all versions and delete markers)
    - ECR Repositories (deleting all images)
    - EC2 Instances (terminating, including disabling termination protection)
    - EC2 Volumes (detaching and deleting)
    - IAM Roles (detaching policies, removing from instance profiles)
    - IAM Policies (detaching from stack-specific roles before deletion)
- Flexible AWS authentication: profile, assumed role, or default SDK chain.
- State persistence: Saves resource lists to a JSON file to allow resumption or review, prompting you to resume or re-scan.
- Dry run mode (`--dry-run`): Simulates operations without making changes.
- User confirmation: Displays all resources and planned actions, requiring explicit approval from you before proceeding.
- Comprehensive logging: To console and timestamped, stack-specific log files.
- Unit tests: For argument parsing, state management, logging, and all resource handlers, using `unittest` and `unittest.mock`.
- Detailed README.md: Provides usage, configuration, and safety information.

The script aims to provide a more robust way for you to delete CloudFormation stacks that are often stuck due to dependent resources not being properly cleaned up by CloudFormation itself.